### PR TITLE
Small simplification to texlive build.sh

### DIFF
--- a/packages/texlive/build.sh
+++ b/packages/texlive/build.sh
@@ -1,10 +1,12 @@
 TERMUX_PKG_HOMEPAGE=https://www.tug.org/texlive/
 TERMUX_PKG_DESCRIPTION="TeX Live is a distribution of the TeX typesetting system."
-TERMUX_PKG_VERSION=20160523
-TERMUX_PKG_SRCURL=ftp://tug.org/historic/systems/texlive/${TERMUX_PKG_VERSION:0:4}/texlive-${TERMUX_PKG_VERSION}b-source.tar.xz
+_MAJOR_VERSION=20160523
+_MINOR_VERSION=b
+TERMUX_PKG_VERSION=${_MAJOR_VERSION}${_MINOR_VERSION}
+TERMUX_PKG_SRCURL=ftp://tug.org/historic/systems/texlive/${TERMUX_PKG_VERSION:0:4}/texlive-${TERMUX_PKG_VERSION}-source.tar.xz
 TERMUX_PKG_SHA256="a8b32ca47f0a403661a09e202f4567a995beb718c18d8f81ca6d76daa1da21ed"
 TERMUX_PKG_DEPENDS="freetype, libpng, libgd, libgmp, libmpfr, libicu, liblua, poppler, libgraphite, harfbuzz, perl, xz-utils"
-TERMUX_PKG_FOLDERNAME=texlive-${TERMUX_PKG_VERSION}-source
+TERMUX_PKG_FOLDERNAME=texlive-${_MAJOR_VERSION}-source
 
 # change the bin directory to "$TERMUX_PREFIX/local/texlive/2016/bin/pkg" because the installer will sinlink this to the actual bin dir..
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="

--- a/packages/texlive/build.sh
+++ b/packages/texlive/build.sh
@@ -36,6 +36,7 @@ BUILDRANLIB=ranlib \
 --disable-mflua \
 --disable-mfluajit \
 --disable-xz \
+--disable-pmx \
 --without-texinfo \
 --without-xdvipdfmx \
 --without-texi2html \
@@ -53,17 +54,13 @@ BUILDRANLIB=ranlib \
 --without-x \
 --with-banner-add=/Termux"
 
-termux_step_post_extract_package () {
-	rm -r $TERMUX_PKG_SRCDIR/utils/pmx
-}
-
 termux_step_post_make_install () {
 	cp $TERMUX_PKG_BUILDER_DIR/termux-install-tl $TERMUX_PREFIX/bin
 }
 
 termux_step_create_debscripts () {
 	echo 'echo "retrieving texlive..."' > postinst
-	echo 'echo "you can start this manually by calling termux-install-tl"' > postinst
+	echo 'echo "you can start this manually by calling termux-install-tl"' >> postinst
 	echo "termux-install-tl" >> postinst
 	echo "exit 0" >> postinst
 	chmod 0755 postinst


### PR DESCRIPTION
It seems that pmx can be disabled instead of being removed prior to build. 

Splitting PKG_VERSION into two parts also gets rid of the need to have a "b" in the texlive SRCURL (some other termux packages also split it into two parts). 

Please let me know if I have missed something crucial. 