### PR TITLE
texlive: improvements of build/installation scripts

### DIFF
--- a/packages/texlive/build.sh
+++ b/packages/texlive/build.sh
@@ -67,7 +67,7 @@ termux_step_create_debscripts () {
 	echo 'echo "retrieving texlive..."' >> postinst
 	echo 'echo "you can start this manually by calling termux-install-tl"' >> postinst
         echo 'echo "========================================================"' >> postinst
-	echo "termux-install-tl.sh" >> postinst
+	echo "termux-install-tl" >> postinst
 	echo "exit 0" >> postinst
 	chmod 0755 postinst
 }

--- a/packages/texlive/build.sh
+++ b/packages/texlive/build.sh
@@ -59,7 +59,7 @@ BUILDRANLIB=ranlib \
 
 
 termux_step_post_make_install () {
-	cp $TERMUX_PKG_BUILDER_DIR/termux-install-tl $TERMUX_PREFIX/bin
+	cp $TERMUX_PKG_BUILDER_DIR/termux-install-tl.sh $TERMUX_PREFIX/bin/termux-install-tl
 }
 
 termux_step_create_debscripts () {
@@ -67,7 +67,7 @@ termux_step_create_debscripts () {
 	echo 'echo "retrieving texlive..."' >> postinst
 	echo 'echo "you can start this manually by calling termux-install-tl"' >> postinst
         echo 'echo "========================================================"' >> postinst
-	echo "termux-install-tl" >> postinst
+	echo "termux-install-tl.sh" >> postinst
 	echo "exit 0" >> postinst
 	chmod 0755 postinst
 }

--- a/packages/texlive/termux-install-tl.sh
+++ b/packages/texlive/termux-install-tl.sh
@@ -3,10 +3,8 @@ TL_VERSION=2016
 TL_ROOT=$PREFIX/opt/texlive
 
 export TMPDIR=$PREFIX/tmp/ 
-cd $TMPDIR
-
-mkdir termux-tl-installer
-cd termux-tl-installer
+mkdir -p $TMPDIR/termux-tl-installer
+cd $TMPDIR/termux-tl-installer
 
 wget -N http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz
 tar xzfv install-tl-unx.tar.gz > flist
@@ -16,7 +14,7 @@ cd $(head -1 flist)
 #patch install-tl
 sed -E -i "s@/bin/sh@$PREFIX/bin/sh@" tlpkg/TeXLive/TLUtils.pm 
 
-cat >> texlive_inst.profile << XXHEREXX
+cat > texlive_inst.profile << XXHEREXX
 
 selected_scheme scheme-custom
 TEXDIR ${TL_ROOT}/${TL_VERSION}
@@ -57,7 +55,10 @@ perl ./install-tl --custom-bin=$TL_ROOT/${TL_VERSION}/bin/pkg --profile texlive_
 mkdir -p $PREFIX/etc/profile.d/
 
 cat > $PREFIX/etc/profile.d/texlive.sh << XXHEREXX
-export PATH=$PATH:$TL_ROOT/${TL_VERSION}/bin/custom
+# Don't append texlive bin-dir to path several times:
+if ! echo "$PATH" | /data/data/com.termux/files/usr/bin/applets/grep -Eq "(^|:)$TL_ROOT/${TL_VERSION}/bin/custom($|:)"; then
+    export PATH=$PATH:$TL_ROOT/${TL_VERSION}/bin/custom
+fi
 export TMPDIR=$PREFIX/tmp/
 
 XXHEREXX

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -29,6 +29,7 @@ PACKAGES+=" scons"
 PACKAGES+=" texinfo"
 PACKAGES+=" xmlto"
 PACKAGES+=" xutils-dev" # Provides 'makedepend' which the openssl build uses.
+PACKAGES+=" gcc-multilib" # Needed for compiling texlive (configuring the library luajit/native fails otherwise).
 
 DEBIAN_FRONTEND=noninteractive sudo apt-get install -yq $PACKAGES
 


### PR DESCRIPTION
Added gcc-multilib to setup-ubuntu.sh (needed for compiling texlive's luajit-native library)
Changed termux-install-tl to not change path if bin-dir is already in path. Also changed script name to termux-install-tl.sh.
Fixed small typo in build.sh and saved a few lines of code.